### PR TITLE
[Rhi][Interface] added Texture View Dimension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ CMakeUserPresets.json
 .vscode/
 .idea/
 vcpkg_installed/
+out/
 
 build/
 build-release/

--- a/Engine/Modules/Rhi/Include/Synergon/Rhi/Descriptors/TextureViewDescriptor.hpp
+++ b/Engine/Modules/Rhi/Include/Synergon/Rhi/Descriptors/TextureViewDescriptor.hpp
@@ -21,7 +21,7 @@ namespace Synergon::Rhi {
 		uint32_t baseArrayLayer  = 0u;
 		uint32_t arrayLayerCount = 1u;
 
-		TextureAspect::Type aspect    = TextureAspect::eColor;
-		TextureDimension    dimension = TextureDimension::e2D;
+		TextureAspect::Type  aspect    = TextureAspect::eColor;
+		TextureViewDimension dimension = TextureViewDimension::e2D;
 	};
 }  // namespace Synergon::Rhi

--- a/Engine/Modules/Rhi/Include/Synergon/Rhi/Enums.hpp
+++ b/Engine/Modules/Rhi/Include/Synergon/Rhi/Enums.hpp
@@ -44,6 +44,16 @@ namespace Synergon::Rhi {
 		eCube = 3,
 	};
 
+	enum class TextureViewDimension {
+		e1D        = 0,
+		e2D        = 1,
+		e3D        = 2,
+		eCube      = 3,
+		e1DArray   = 4,
+		e2DArray   = 5,
+		eCubeArray = 6,
+	};
+
 	struct TextureAspect {
 		typedef uint8_t Type;
 


### PR DESCRIPTION
Texture View Dimension is different from Texture Dimension

e.g.
TextureDimenion can be e3D, but the view can be TextureViewDimension::e2DArray